### PR TITLE
Declare a Go module by creating go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/DevelHell/popgun
+
+go 1.23


### PR DESCRIPTION
I put "go 1.23" as the minimum version of Go,
which is the oldest still supported version at the time of writing.

See https://go.dev/doc/modules/gomod-ref#go-notes for reference.