### PR TITLE
Revert "revert msg numbering because of mail clients confusion"

### DIFF
--- a/command.go
+++ b/command.go
@@ -122,7 +122,7 @@ func (cmd ListCommand) Run(c *Client, args []string) (int, error) {
 		c.printer.Ok("%d messages", len(octets))
 		messagesList := make([]string, len(octets))
 		for i, octet := range octets {
-			messagesList[i] = fmt.Sprintf("%d %d", i, octet)
+			messagesList[i] = fmt.Sprintf("%d %d", i+1, octet)
 		}
 		c.printer.MultiLine(messagesList)
 	}
@@ -239,7 +239,7 @@ func (cmd UidlCommand) Run(c *Client, args []string) (int, error) {
 		c.printer.Ok("%d messages", len(uids))
 		uidsList := make([]string, len(uids))
 		for i, uid := range uids {
-			uidsList[i] = fmt.Sprintf("%d %s", i, uid)
+			uidsList[i] = fmt.Sprintf("%d %s", i+1, uid)
 		}
 		c.printer.MultiLine(uidsList)
 	}

--- a/command_test.go
+++ b/command_test.go
@@ -203,7 +203,7 @@ func TestListCommand_Run(t *testing.T) {
 			args:           []string{},
 			expectedState:  STATE_TRANSACTION,
 			expectedErr:    false,
-			expectedOutput: "^\\+OK 5 messages\r\n0 10\r\n1 10\r\n2 10\r\n3 10\r\n4 10\r\n\\.",
+			expectedOutput: "^\\+OK 5 messages\r\n1 10\r\n2 10\r\n3 10\r\n4 10\r\n5 10\r\n\\.",
 		},
 	}
 
@@ -384,7 +384,7 @@ func TestUidlCommand_Run(t *testing.T) {
 			args:           []string{},
 			expectedState:  STATE_TRANSACTION,
 			expectedErr:    false,
-			expectedOutput: "^\\+OK 5 messages\r\n0 1\r\n1 2\r\n2 3\r\n3 4\r\n4 5\r\n\\.",
+			expectedOutput: "^\\+OK 5 messages\r\n1 1\r\n2 2\r\n3 3\r\n4 4\r\n5 5\r\n\\.",
 		},
 	}
 


### PR DESCRIPTION
This reverts commit 1a9e699090b3e9012a182bca2a9822e1d878e15a.

Mail clients such as mpop require messages starting at 1: https://sources.debian.org/src/mpop/1.4.12-1/src/pop3.c/#L1306

cc @DevelHell